### PR TITLE
Fix #37: Fix for scrollbar missing on ajax requests

### DIFF
--- a/assets/linklist.js
+++ b/assets/linklist.js
@@ -1,36 +1,34 @@
-/* js for the linklist module site */
-$(document).ready(function() {
-    // set niceScroll to linklist
-    $(".panel-linklist-widget .linklist-body .scrollable-content-container").niceScroll({
-        cursorwidth: "7",
-        cursorborder:"",
-        cursorcolor:"#555",
-        cursoropacitymax:"0.2",
-        railpadding:{top:0,right:3,left:0,bottom:0}
-    });
-    $(".panel-linklist-widget .linklist-body .scrollable-content-container").getNiceScroll().resize();
-    
-    $(".toggle-view-mode a").on("click", function(e) {
-    	e.preventDefault();
-    	console.log(jQuery(this));
-    	if(jQuery(this).data('enabled')) {
-    		jQuery(this).data('enabled', false);
-    		$(".linklist-editable").hide();
-    		$(".linklist-categories").sortable('disable');
-    		$(".linklist-links").sortable('disable');
-    	}
-    	else {
-    		jQuery(this).data('enabled', true);
-    		$(".linklist-editable").show();
-    		$(".linklist-categories").sortable('enable');
-    		$(".linklist-links").sortable('enable');
-    	}
-    });
-    
-});
-
 humhub.module('linklist', function (module, require, $) {
 	var client = require('client');
+
+	var init = function () {
+		// set niceScroll to linklist
+		$(".panel-linklist-widget .linklist-body .scrollable-content-container").niceScroll({
+			cursorwidth: "7",
+			cursorborder:"",
+			cursorcolor:"#555",
+			cursoropacitymax:"0.2",
+			railpadding:{top:0,right:3,left:0,bottom:0}
+		});
+		$(".panel-linklist-widget .linklist-body .scrollable-content-container").getNiceScroll().resize();
+
+		$(".toggle-view-mode a").on("click", function(e) {
+			e.preventDefault();
+			if(jQuery(this).data('enabled')) {
+				jQuery(this).data('enabled', false);
+				$(".linklist-editable").hide();
+				$(".linklist-categories").sortable('disable');
+				$(".linklist-links").sortable('disable');
+			}
+			else {
+				jQuery(this).data('enabled', true);
+				$(".linklist-editable").show();
+				$(".linklist-categories").sortable('enable');
+				$(".linklist-links").sortable('enable');
+			}
+		});
+	}
+
 	var removeCategory = function(event) {
 		client.post(event);
 
@@ -62,5 +60,7 @@ humhub.module('linklist', function (module, require, $) {
 	module.export({
 		removeCategory: removeCategory,
 		removeLink: removeLink,
+		init,
+		initOnPjaxLoad: true,
 	});
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 0.8.4 (Unreleased)
 -----------------------
 - Fix #64: Fix visibility of the method `Controller::getAccessRules()`
+- Fix #37: Fix for scrollbar missing on ajax requests
 
 0.8.3 (August 26, 2023)
 -----------------------


### PR DESCRIPTION
On page (re)load niceScroll gets initialized - for ajax requests niceScroll initialization is not triggered (DOM ready).
Example for an ajax request is a switch between spaces.